### PR TITLE
fix: sign off every commit gomgr writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ delete_unmanaged_repos: false       # delete repos not defined in any team (DEST
 delete_unmanaged_custom_roles: false # delete custom roles not in org.yaml (DESTRUCTIVE!)
 create_repo: true                   # create repos if missing when referenced by teams
 
+# Sign every commit gomgr writes with a Signed-off-by trailer. Required when
+# the org enforces DCO via a ruleset `commit_message_pattern` rule — gomgr
+# commits straight to the default branch, so no pull-request DCO check ever
+# runs on them and an unsigned message is rejected at push time.
+# Empty (the default) appends nothing.
+sign_off: "my-app[bot] <12345+my-app[bot]@users.noreply.github.com>"
+
 # Legacy convenience flags — still honoured, but `files:` is the preferred
 # way to declare per-repo content. Legacy flags are materialised into
 # FileSpec entries at load time.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -20,6 +20,17 @@ type AppConfig struct {
 	DeleteStaleCodeowners      bool `yaml:"delete_stale_codeowners"`
 	CreateRepo                 bool `yaml:"create_repo"`
 
+	// SignOff is the identity used for the Signed-off-by trailer appended to
+	// every commit gomgr writes, in "Name <email>" form. Set it when the org
+	// enforces DCO — a ruleset with a commit_message_pattern rule requiring
+	// "Signed-off-by:" rejects gomgr's file-sync pushes otherwise, because
+	// those commits go straight to the default branch and never pass through
+	// a pull request where a DCO check could run.
+	//
+	// Empty (the default) appends nothing, preserving prior behavior for orgs
+	// that do not require sign-off.
+	SignOff string `yaml:"sign_off,omitempty"`
+
 	// Files declares templated files that should exist in every managed
 	// repository. Each entry's Content is rendered through text/template with
 	// {Org, Repo} context. Only (optional) limits which repos an entry applies

--- a/internal/sync/files.go
+++ b/internal/sync/files.go
@@ -17,6 +17,25 @@ const defaultFileBranch = "main"
 // the file stays out of the repo root.
 const codeownersPath = ".github/CODEOWNERS"
 
+// signOffPrefix is the trailer key DCO tooling and commit_message_pattern
+// rulesets look for.
+const signOffPrefix = "Signed-off-by:"
+
+// withSignOff appends a Signed-off-by trailer to a commit message so the
+// commit satisfies DCO rulesets. It is a no-op when signOff is empty or when
+// the message already carries a trailer — user-supplied app.files[].message
+// values may sign themselves off, and double trailers are not harmful but are
+// noise in the log.
+//
+// The trailer is separated by a blank line so it forms a proper git trailer
+// block rather than being folded into the subject or body.
+func withSignOff(message, signOff string) string {
+	if signOff == "" || strings.Contains(message, signOffPrefix) {
+		return message
+	}
+	return strings.TrimRight(message, "\n") + "\n\n" + signOffPrefix + " " + signOff
+}
+
 // materializeFileSpecs merges user-declared app.files with any legacy
 // convenience flags (AddDefaultReadme, AddRenovateConfig) so downstream code
 // only has to iterate a single list. Legacy entries are prepended; if a user
@@ -56,7 +75,11 @@ func materializeFileSpecs(app config.AppConfig) []config.FileSpec {
 // Only filter) and returns a list of repo-file:ensure changes. emittedFiles is
 // updated in place so the same path is only emitted once per repo, even when
 // multiple teams reference the same repository.
-func planRepoFiles(org, repo, repoKey string, specs []config.FileSpec, emittedFiles map[string]bool) ([]util.Change, error) {
+//
+// signOff, when non-empty, is appended to every commit message as a
+// Signed-off-by trailer. It is applied here rather than at apply time so a dry
+// run shows the message that will actually be committed.
+func planRepoFiles(org, repo, repoKey string, specs []config.FileSpec, signOff string, emittedFiles map[string]bool) ([]util.Change, error) {
 	var out []util.Change
 	for _, spec := range specs {
 		if !templates.MatchesRepo(spec, repo) {
@@ -76,6 +99,7 @@ func planRepoFiles(org, repo, repoKey string, specs []config.FileSpec, emittedFi
 		if message == "" {
 			message = fmt.Sprintf("chore: add %s", spec.Path)
 		}
+		message = withSignOff(message, signOff)
 		branch := spec.Branch
 		if branch == "" {
 			branch = defaultFileBranch
@@ -136,7 +160,7 @@ func renderCodeowners(owners []string) string {
 //
 // ownersByRepo is keyed by lower-cased repo name; repoNames maps that key
 // back to the canonical name for the apply payload.
-func planCodeowners(org string, ownersByRepo map[string][]string, repoNames map[string]string, userFilePaths map[string]bool, emittedFiles map[string]bool) []util.Change {
+func planCodeowners(org string, ownersByRepo map[string][]string, repoNames map[string]string, userFilePaths map[string]bool, signOff string, emittedFiles map[string]bool) []util.Change {
 	if userFilePaths[codeownersPath] {
 		return nil
 	}
@@ -170,7 +194,7 @@ func planCodeowners(org string, ownersByRepo map[string][]string, repoNames map[
 				"repo":      repoName,
 				"path":      codeownersPath,
 				"content":   content,
-				"message":   "chore: sync CODEOWNERS",
+				"message":   withSignOff("chore: sync CODEOWNERS", signOff),
 				"branch":    defaultFileBranch,
 				"reconcile": true,
 			},
@@ -188,7 +212,7 @@ func planCodeowners(org string, ownersByRepo map[string][]string, repoNames map[
 // The apply handler is idempotent — a delete against a repo with no
 // .github/CODEOWNERS no-ops — so this can safely fire for repos that never
 // had the file.
-func planCodeownersDeletions(org string, managedRepos map[string]bool, repoNames map[string]string, ownersByRepo map[string][]string, userFilePaths map[string]bool, emittedFiles map[string]bool) []util.Change {
+func planCodeownersDeletions(org string, managedRepos map[string]bool, repoNames map[string]string, ownersByRepo map[string][]string, userFilePaths map[string]bool, signOff string, emittedFiles map[string]bool) []util.Change {
 	if userFilePaths[codeownersPath] {
 		return nil
 	}
@@ -219,7 +243,7 @@ func planCodeownersDeletions(org string, managedRepos map[string]bool, repoNames
 				"org":     org,
 				"repo":    repoName,
 				"path":    codeownersPath,
-				"message": "chore: remove stale CODEOWNERS",
+				"message": withSignOff("chore: remove stale CODEOWNERS", signOff),
 				"branch":  defaultFileBranch,
 			},
 		})

--- a/internal/sync/files_test.go
+++ b/internal/sync/files_test.go
@@ -49,6 +49,103 @@ func TestMaterializeFileSpecs_UserOverridesLegacy(t *testing.T) {
 	}
 }
 
+const testSignOff = "dsec-gom[bot] <224359171+dsec-gom[bot]@users.noreply.github.com>"
+
+func TestWithSignOff(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		signOff string
+		want    string
+	}{
+		{
+			name:    "empty signOff leaves the message untouched",
+			message: "chore: add LICENSE",
+			signOff: "",
+			want:    "chore: add LICENSE",
+		},
+		{
+			name:    "trailer is separated by a blank line",
+			message: "chore: add LICENSE",
+			signOff: testSignOff,
+			want:    "chore: add LICENSE\n\nSigned-off-by: " + testSignOff,
+		},
+		{
+			name:    "already signed off is left alone",
+			message: "chore: add LICENSE\n\nSigned-off-by: Someone <someone@example.com>",
+			signOff: testSignOff,
+			want:    "chore: add LICENSE\n\nSigned-off-by: Someone <someone@example.com>",
+		},
+		{
+			name:    "trailing newlines are collapsed before the trailer",
+			message: "chore: add LICENSE\n\n",
+			signOff: testSignOff,
+			want:    "chore: add LICENSE\n\nSigned-off-by: " + testSignOff,
+		},
+		{
+			name:    "multi-line body keeps its body",
+			message: "chore: add LICENSE\n\nBecause the auditors asked.",
+			signOff: testSignOff,
+			want:    "chore: add LICENSE\n\nBecause the auditors asked.\n\nSigned-off-by: " + testSignOff,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := withSignOff(tc.message, tc.signOff); got != tc.want {
+				t.Errorf("withSignOff(%q, %q) = %q, want %q", tc.message, tc.signOff, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanRepoFiles_SignsOffCustomAndDefaultMessages(t *testing.T) {
+	specs := []config.FileSpec{
+		{Path: "README.md", Content: "hi", Message: "chore: readme"},
+		{Path: "LICENSE", Content: "MIT\n"},
+	}
+
+	changes, err := planRepoFiles("Acme", "widgets", "widgets", specs, testSignOff, map[string]bool{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 changes, got %d", len(changes))
+	}
+
+	want := "chore: readme\n\nSigned-off-by: " + testSignOff
+	if got := changes[0].Details.(map[string]any)["message"]; got != want {
+		t.Errorf("custom message: got %q, want %q", got, want)
+	}
+	want = "chore: add LICENSE\n\nSigned-off-by: " + testSignOff
+	if got := changes[1].Details.(map[string]any)["message"]; got != want {
+		t.Errorf("default message: got %q, want %q", got, want)
+	}
+}
+
+func TestPlanCodeowners_SignsOffSyncAndDeleteMessages(t *testing.T) {
+	owners := map[string][]string{"widgets": {"@acme/platform"}}
+	names := map[string]string{"widgets": "widgets"}
+
+	changes := planCodeowners("acme", owners, names, map[string]bool{}, testSignOff, map[string]bool{})
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 codeowners change, got %d", len(changes))
+	}
+	want := "chore: sync CODEOWNERS\n\nSigned-off-by: " + testSignOff
+	if got := changes[0].Details.(map[string]any)["message"]; got != want {
+		t.Errorf("sync message: got %q, want %q", got, want)
+	}
+
+	managed := map[string]bool{"widgets": true}
+	deletions := planCodeownersDeletions("acme", managed, names, map[string][]string{}, map[string]bool{}, testSignOff, map[string]bool{})
+	if len(deletions) != 1 {
+		t.Fatalf("expected 1 deletion change, got %d", len(deletions))
+	}
+	want = "chore: remove stale CODEOWNERS\n\nSigned-off-by: " + testSignOff
+	if got := deletions[0].Details.(map[string]any)["message"]; got != want {
+		t.Errorf("delete message: got %q, want %q", got, want)
+	}
+}
+
 func TestPlanRepoFiles_RendersAndDedupes(t *testing.T) {
 	specs := []config.FileSpec{
 		{Path: "README.md", Content: "# {{.Repo}} in {{.Org}}", Message: "chore: readme", Branch: "main"},
@@ -56,7 +153,7 @@ func TestPlanRepoFiles_RendersAndDedupes(t *testing.T) {
 	}
 	emitted := map[string]bool{}
 
-	changes, err := planRepoFiles("Acme", "widgets", "widgets", specs, emitted)
+	changes, err := planRepoFiles("Acme", "widgets", "widgets", specs, "", emitted)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +181,7 @@ func TestPlanRepoFiles_RendersAndDedupes(t *testing.T) {
 	}
 
 	// Calling again should be a no-op because emitted tracks both paths now.
-	more, err := planRepoFiles("Acme", "widgets", "widgets", specs, emitted)
+	more, err := planRepoFiles("Acme", "widgets", "widgets", specs, "", emitted)
 	if err != nil {
 		t.Fatalf("unexpected error on second call: %v", err)
 	}
@@ -97,7 +194,7 @@ func TestPlanRepoFiles_OnlyGlobSkipsNonMatch(t *testing.T) {
 	specs := []config.FileSpec{
 		{Path: "LICENSE", Content: "MIT", Only: []string{"public-*"}},
 	}
-	changes, err := planRepoFiles("Acme", "internal-api", "internal-api", specs, map[string]bool{})
+	changes, err := planRepoFiles("Acme", "internal-api", "internal-api", specs, "", map[string]bool{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -105,7 +202,7 @@ func TestPlanRepoFiles_OnlyGlobSkipsNonMatch(t *testing.T) {
 		t.Errorf("expected no changes for non-matching repo, got %d", len(changes))
 	}
 
-	changes, err = planRepoFiles("Acme", "public-docs", "public-docs", specs, map[string]bool{})
+	changes, err = planRepoFiles("Acme", "public-docs", "public-docs", specs, "", map[string]bool{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,7 +213,7 @@ func TestPlanRepoFiles_OnlyGlobSkipsNonMatch(t *testing.T) {
 
 func TestPlanRepoFiles_BadTemplatePropagates(t *testing.T) {
 	specs := []config.FileSpec{{Path: "bad.md", Content: "{{.Missing}}"}}
-	_, err := planRepoFiles("Acme", "widgets", "widgets", specs, map[string]bool{})
+	_, err := planRepoFiles("Acme", "widgets", "widgets", specs, "", map[string]bool{})
 	if err == nil {
 		t.Fatal("expected template error")
 	}
@@ -169,7 +266,7 @@ func TestPlanCodeowners_EmitsPerRepo(t *testing.T) {
 	names := map[string]string{"api": "api", "web": "web"}
 	emitted := map[string]bool{}
 
-	changes := planCodeowners("acme", owners, names, map[string]bool{}, emitted)
+	changes := planCodeowners("acme", owners, names, map[string]bool{}, "", emitted)
 	if len(changes) != 2 {
 		t.Fatalf("expected 2 changes, got %d", len(changes))
 	}
@@ -201,7 +298,7 @@ func TestPlanCodeowners_SkipsWhenUserDeclared(t *testing.T) {
 	names := map[string]string{"api": "api"}
 	userFiles := map[string]bool{".github/CODEOWNERS": true}
 
-	changes := planCodeowners("acme", owners, names, userFiles, map[string]bool{})
+	changes := planCodeowners("acme", owners, names, userFiles, "", map[string]bool{})
 	if len(changes) != 0 {
 		t.Errorf("expected user-declared CODEOWNERS to win, got %d synthesized changes", len(changes))
 	}
@@ -213,7 +310,7 @@ func TestPlanCodeowners_SkipsRepoWithoutOwners(t *testing.T) {
 		"empty": nil,
 	}
 	names := map[string]string{"api": "api", "empty": "empty"}
-	changes := planCodeowners("acme", owners, names, map[string]bool{}, map[string]bool{})
+	changes := planCodeowners("acme", owners, names, map[string]bool{}, "", map[string]bool{})
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change (api only), got %d", len(changes))
 	}
@@ -227,7 +324,7 @@ func TestPlanCodeowners_RespectsEmittedSet(t *testing.T) {
 	names := map[string]string{"api": "api"}
 	emitted := map[string]bool{"api:.github/CODEOWNERS": true}
 
-	changes := planCodeowners("acme", owners, names, map[string]bool{}, emitted)
+	changes := planCodeowners("acme", owners, names, map[string]bool{}, "", emitted)
 	if len(changes) != 0 {
 		t.Errorf("expected no changes when already emitted, got %d", len(changes))
 	}
@@ -238,7 +335,7 @@ func TestPlanCodeownersDeletions_OnlyForReposWithoutOwners(t *testing.T) {
 	names := map[string]string{"api": "api", "web": "web", "infra": "infra"}
 	owners := map[string][]string{"api": {"octocat"}}
 
-	changes := planCodeownersDeletions("acme", managed, names, owners, map[string]bool{}, map[string]bool{})
+	changes := planCodeownersDeletions("acme", managed, names, owners, map[string]bool{}, "", map[string]bool{})
 	if len(changes) != 2 {
 		t.Fatalf("expected 2 delete changes (web, infra), got %d", len(changes))
 	}
@@ -264,7 +361,7 @@ func TestPlanCodeownersDeletions_SkipsWhenUserDeclared(t *testing.T) {
 	owners := map[string][]string{} // no owners -> would normally delete
 	userFiles := map[string]bool{".github/CODEOWNERS": true}
 
-	changes := planCodeownersDeletions("acme", managed, names, owners, userFiles, map[string]bool{})
+	changes := planCodeownersDeletions("acme", managed, names, owners, userFiles, "", map[string]bool{})
 	if len(changes) != 0 {
 		t.Errorf("expected user-declared CODEOWNERS to suppress deletion, got %d", len(changes))
 	}
@@ -275,7 +372,7 @@ func TestPlanCodeownersDeletions_RespectsEmittedSet(t *testing.T) {
 	names := map[string]string{"api": "api"}
 	emitted := map[string]bool{"api:.github/CODEOWNERS": true}
 
-	changes := planCodeownersDeletions("acme", managed, names, map[string][]string{}, map[string]bool{}, emitted)
+	changes := planCodeownersDeletions("acme", managed, names, map[string][]string{}, map[string]bool{}, "", emitted)
 	if len(changes) != 0 {
 		t.Errorf("expected no changes when already emitted (write wins), got %d", len(changes))
 	}

--- a/internal/sync/teams.go
+++ b/internal/sync/teams.go
@@ -688,7 +688,7 @@ func planRepoPerms(ctx context.Context, c *gh.Client, cfg *config.Root, st *Stat
 			}
 
 			// Emit file changes only once per repo (skip if already emitted from another team)
-			fileChanges, err := planRepoFiles(org, repo, r, fileSpecs, emittedFiles)
+			fileChanges, err := planRepoFiles(org, repo, r, fileSpecs, cfg.App.SignOff, emittedFiles)
 			if err != nil {
 				return nil, err
 			}
@@ -696,9 +696,9 @@ func planRepoPerms(ctx context.Context, c *gh.Client, cfg *config.Root, st *Stat
 		}
 	}
 
-	out = append(out, planCodeowners(org, desiredOwners, repoNames, userFilePaths, emittedFiles)...)
+	out = append(out, planCodeowners(org, desiredOwners, repoNames, userFilePaths, cfg.App.SignOff, emittedFiles)...)
 	if cfg.App.DeleteStaleCodeowners {
-		out = append(out, planCodeownersDeletions(org, managedRepos, repoNames, desiredOwners, userFilePaths, emittedFiles)...)
+		out = append(out, planCodeownersDeletions(org, managedRepos, repoNames, desiredOwners, userFilePaths, cfg.App.SignOff, emittedFiles)...)
 	}
 
 	// Plan topic updates


### PR DESCRIPTION
## Problem

gomgr writes repo files straight to the default branch via the Contents API, so its commits never pass through a pull request where a DCO check could run.

The `DragonSecurity` org now enforces DCO with a ruleset `commit_message_pattern` rule requiring `Signed-off-by:` on `~DEFAULT_BRANCH` across `~ALL` repos, with an empty bypass list. Every gomgr file-sync push is rejected at push time under that rule — `repo-file:ensure` and `repo-file:delete` alike.

Every commit message gomgr produces was unsigned:

- `files.go` — `"chore: add Renovate config"`
- `files.go` — default `fmt.Sprintf("chore: add %s", spec.Path)`
- `files.go` — `"chore: sync CODEOWNERS"`
- `files.go` — `"chore: remove stale CODEOWNERS"`
- `spec.Message` passed through from `app.files[].message`

## Change

Adds an optional app-level `sign_off` identity (`"Name <email>"`) and appends it as a `Signed-off-by` trailer to each planned commit message.

Applied at **plan** time rather than apply time, for two reasons: the apply handlers have a fixed `(ctx, *gh.Client, util.Change)` signature resolved through a package-level registry, so reaching config from there needs either a wider refactor or mutable package state; and doing it in the planner means a dry run prints the message that will actually be committed.

`withSignOff` is idempotent — it skips when the message already contains `Signed-off-by:`, so a hand-signed `app.files[].message` does not get a double trailer.

Empty `sign_off` (the default) appends nothing, preserving behavior for orgs that do not require sign-off.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./...` passes
- 3 new tests, 8 cases: empty sign-off, trailer separation, already-signed-off, trailing-newline collapse, multi-line body, plus plan-level coverage for custom/default file messages and the CODEOWNERS sync/delete messages