### PR TITLE
fix(ci): bump test matrix to Go 1.26.5 to match go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.26.4']
+        go-version: ['1.26.5']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
`main` is currently red, and so is every open PR.

#102 raised the `go` directive in `go.mod` to 1.26.5 but left the `test` job's matrix pinned at `1.26.4`. With `GOTOOLCHAIN=local` the job cannot satisfy the directive and dies at `make mod-download`:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
make: *** [Makefile:110: mod-download] Error 1
```

The `lint`, `security` and `build` jobs hardcode `'1.26.5'`, so only the `test` job broke — which is why this slipped through: #102's own checks ran against the pre-merge base.

This blocks #97, #99 and #107. Merge this first and the rest go green on rebase.

### Worth a follow-up

The matrix and the three hardcoded `go-version: '1.26.5'` strings are four copies of one fact that already lives in `go.mod`. `actions/setup-go` supports `go-version-file: go.mod`, which would make this class of drift impossible. Out of scope here — this PR just unbreaks CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)