### PR TITLE
fix: stamp the release tag into gomgr version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,11 @@ jobs:
           BIN=gomgr
           if [ "${{ matrix.goos }}" = "windows" ]; then BIN=gomgr.exe; fi
           mkdir -p build
-          go build -trimpath -ldflags "-s" -o build/$BIN ./main.go
+          # Build the package, not ./main.go: a file-list build is
+          # "command-line-arguments" and gets no VCS stamping at all.
+          go build -trimpath \
+            -ldflags "-s -X github.com/DragonSecurity/gomgr/internal/version.stamped=${VERSION}" \
+            -o build/$BIN .
 
       - name: Package
         run: |

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,6 +4,13 @@ import (
 	"runtime/debug"
 )
 
+// stamped is set at link time by the release build with
+// -ldflags "-X github.com/DragonSecurity/gomgr/internal/version.stamped=vX.Y.Z"
+// so a released binary reports its tag. Nothing else can supply it: the module
+// version recorded in the binary is only meaningful for `go install
+// module@version`, and the VCS revision is a commit hash, not a tag.
+var stamped string
+
 // BuildInfo contains version and build information
 type BuildInfo struct {
 	Version    string
@@ -36,6 +43,13 @@ func GetBuildInfo() BuildInfo {
 		case "vcs.modified":
 			info.Modified = setting.Value == "true"
 		}
+	}
+
+	// A link-time stamp is the only source that carries the release tag, so it
+	// wins over the revision and module fallbacks below.
+	if stamped != "" {
+		info.Version = stamped
+		return info
 	}
 
 	// Use VCS revision as version if available, otherwise check for version in main module

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -8,3 +8,15 @@ func TestGetBuildInfo(t *testing.T) {
 		t.Error("expected non-empty Version field")
 	}
 }
+
+// A released binary is stamped with its tag at link time; that stamp has to
+// win over the VCS revision, which is only ever a commit hash.
+func TestGetBuildInfoPrefersStampedVersion(t *testing.T) {
+	prev := stamped
+	t.Cleanup(func() { stamped = prev })
+
+	stamped = "v1.2.3"
+	if got := GetBuildInfo().Version; got != "v1.2.3" {
+		t.Errorf("Version = %q, want %q", got, "v1.2.3")
+	}
+}


### PR DESCRIPTION
## Problem

`gomgr version` reports `dev` on every released binary, including v0.2.9. This surfaced while debugging a DCO failure in the org config repo, where the `dev` output made it look like the wrong binary had been downloaded — it hadn't.

## Causes

Two independent ones, both in `.github/workflows/release.yaml`:

1. The build ran `go build ... ./main.go`. A file-list build compiles as `command-line-arguments`, not as the module's main package, and gets **no** VCS stamping. Verified locally — the file-list binary has no `vcs.revision` in `go version -m`; building `.` does.
2. `VERSION=${GITHUB_REF_NAME}` was computed into the env but never reached the linker, and `GetBuildInfo` had no way to receive a tag regardless.

## Fix

- `internal/version`: add a `stamped` var set via `-X` at link time, preferred over the revision and module fallbacks. A revision is a commit hash — it can't tell an operator that the binary they pinned is v0.2.9.
- Release workflow: build `.` instead of `./main.go`, and pass `-X ...version.stamped=${VERSION}`.

Unstamped builds (local `go build`, `go install`) keep their existing behavior.

## Verification

- `go build ./... && go vet ./... && go test ./...` — all pass.
- A locally stamped build prints `Version: v0.2.10` alongside its revision.
- New test asserts the stamp wins over the VCS revision.

Takes effect on the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)